### PR TITLE
Add native_unit_of_measurement 'conn' for active connections sensor

### DIFF
--- a/custom_components/keenetic_router_pro/sensor.py
+++ b/custom_components/keenetic_router_pro/sensor.py
@@ -510,6 +510,10 @@ class KeeneticActiveConnectionsSensor(BaseKeeneticSensor):
         return "Active Connections"
 
     @property
+    def native_unit_of_measurement(self) -> str:
+        return "conn"
+
+    @property
     def native_value(self) -> int:
         sys = self._system
         conntotal = sys.get("conntotal", 0)


### PR DESCRIPTION
It fixes display of active connections sensor data.
<details>
<summary>Before</summary>
<img width="960" height="726" alt="attach_before" src="https://github.com/user-attachments/assets/94da11aa-03dc-4c64-8047-0bb408b100e0" />
</details>
<details>
<summary>After</summary>
<img width="981" height="491" alt="attach_after" src="https://github.com/user-attachments/assets/e758371c-37c2-4a17-8813-c85ac4441069" />
</details>