### PR TITLE
Fixed a bug with the status of repeaters

### DIFF
--- a/custom_components/keenetic_router_pro/api.py
+++ b/custom_components/keenetic_router_pro/api.py
@@ -740,7 +740,7 @@ class KeeneticClient:
                 
                 is_connected = (
                     rci_info.get("errors", 0) == 0 
-                    or member.get("internet-available", False)
+                    and member.get("internet-available", False)
                 )
 
                 nodes.append({


### PR DESCRIPTION
This corrects the connection status of the repeaters.

Prior to this, the repeater was always connected with the status when the repeater was physically disconnected or when it was rebooted.

<details>
<summary>Before that, during a reboot of the repeater</summary>
<img width="408" height="193" alt="image" src="https://github.com/user-attachments/assets/7ce0853e-bec0-4e6e-97f3-0ee67132c8cb" />
<img width="408" height="185" alt="image" src="https://github.com/user-attachments/assets/743d6b2c-0431-475b-bf9f-ea1b1f607144" />

</details>
<details>
<summary>After</summary>
<img width="408" height="193" alt="image" src="https://github.com/user-attachments/assets/bcf5b939-6d44-4abe-a09d-392dd323c41a" />
<img width="408" height="175" alt="image" src="https://github.com/user-attachments/assets/ba45285c-8f85-455c-9816-1bceb9b3fa29" />

</details>