### PR TITLE
Fix: cache missing guest Wi-Fi interfaces to prevent log flooding (#49)

### DIFF
--- a/custom_components/keenetic_router_pro/api.py
+++ b/custom_components/keenetic_router_pro/api.py
@@ -1101,6 +1101,14 @@ class KeeneticClient:
             if not ssid and not group:
                 continue
 
+            # Issue #49 fix (extended): skip interfaces already confirmed
+            # missing on a previous tick (e.g. WifiMaster0/AccessPoint1 on
+            # routers without Guest Wi-Fi). Prevents the orphan-AP SSID
+            # inheritance from re-surfacing the phantom interface after the
+            # coordinator cache clears on HA reload.
+            if raw_id in self._missing_interface_paths:
+                continue
+
             clone = dict(item)
             clone["__id"] = raw_id
             ap_items.append(clone)

--- a/custom_components/keenetic_router_pro/coordinator.py
+++ b/custom_components/keenetic_router_pro/coordinator.py
@@ -244,13 +244,20 @@ class KeeneticCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         wifi_passwords: dict[str, str] = {}
         if self.data:
             wifi_passwords = dict(self.data.get("wifi_passwords", {}))
- 
+            
+        # Issue #49 fix (coordinator layer): cache "" sentinel for interfaces
+        # where async_get_wifi_password returned None (non-existent APs like
+        # WifiMaster0/AccessPoint1 on routers without Guest Wi-Fi).
+        # Previously only truthy passwords were stored, so a None result was
+        # never cached and the same interface was re-queued every tick,
+        # generating 4-6 router-log errors per 10 seconds indefinitely.
+        # We now store "" as a sentinel meaning "confirmed missing — skip".
         missing_pw_targets = [
             (net.get("id"), net.get("ssid"))
             for net in wifi
             if net.get("id")
             and net.get("ssid")
-            and net.get("id") not in wifi_passwords
+            and net.get("id") not in wifi_passwords  # "" sentinel also excluded
         ]
         if missing_pw_targets:
             pw_results = await asyncio.gather(
@@ -263,8 +270,9 @@ class KeeneticCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             for (iface_id, _ssid), pw in zip(missing_pw_targets, pw_results):
                 if isinstance(pw, BaseException):
                     continue
-                if pw:
-                    wifi_passwords[iface_id] = pw
+                # Store the password if found, or "" sentinel so this
+                # interface is permanently skipped on subsequent ticks.
+                wifi_passwords[iface_id] = pw if pw else ""
  
         # ---------- Stage 3b: Mesh USB (parallel per node) ----------
         # Each connected mesh node is queried directly at its own IP


### PR DESCRIPTION
### Description
This PR resolves issue #49 where routers without a Guest Wi-Fi setup (missing interfaces like `WifiMaster0/AccessPoint1`) would continuously flood the router logs with 4-6 errors every 10 seconds. 

### Root Cause
Previously, the coordinator layer only cached truthy passwords returned by `async_get_wifi_password`. If an interface didn't exist and returned `None`, it was never stored in the cache. As a result, the same non-existent interfaces were re-queued every single tick, causing indefinite log spam.

### Changes Introduced
1. **Cache Empty Sentinel:** Implemented a `""` (empty string) sentinel value in the coordinator layer cache for interfaces where `async_get_wifi_password` returns `None`. This marks them as "confirmed missing" so they are skipped on subsequent ticks.
2. **Persistent Skip across Reloads:** Extended the logic to actively skip these confirmed-missing interfaces, preventing orphan-AP SSID inheritance from re-surfacing the phantom interfaces even after the coordinator cache clears (e.g., during a Home Assistant reload).

### Fixes
Fixes #49