### PR TITLE
fix(coordinator): cache "" sentinel for missing APs to stop infinite AccessPoint1 log spam

### DIFF
--- a/custom_components/keenetic_router_pro/coordinator.py
+++ b/custom_components/keenetic_router_pro/coordinator.py
@@ -270,8 +270,11 @@ class KeeneticCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             for (iface_id, _ssid), pw in zip(missing_pw_targets, pw_results):
                 if isinstance(pw, BaseException):
                     continue
-                if pw:
-                    wifi_passwords[iface_id] = pw
+                # Store the password if found, or "" sentinel so this
+                # interface is permanently skipped on subsequent ticks.
+                # Without this, None (returned for non-existent APs like
+                # AccessPoint1) is never cached and re-queued every tick.
+                wifi_passwords[iface_id] = pw if pw else ""
  
         # ---------- Stage 3b: Mesh USB (parallel per node) ----------
         # Each connected mesh node is queried directly at its own IP


### PR DESCRIPTION
## Problem

After the recent refactor, the coordinator comment correctly describes
the intended caching behaviour, but the code still uses the old `if pw:`
guard — so `None` (returned for non-existent APs like
`WifiMaster0/AccessPoint1` on routers without Guest Wi-Fi) is never
stored in `wifi_passwords`. This means the interface is re-queued on
every tick, generating 4–6 router-log errors per 10 seconds indefinitely
(~2 400 errors/hour).

## Root Cause

```python
# Current code — broken
if pw:                           # None is falsy
    wifi_passwords[iface_id] = pw    # never cached for missing APs
```

The comment above this block says "subsequent ticks skip these calls
entirely" — but that only works for APs that return a real password.
Missing APs are re-polled forever.

## Fix

```python
# One-line fix
wifi_passwords[iface_id] = pw if pw else ""
```

`""` acts as a sentinel: it satisfies `id not in wifi_passwords` being
`False` on the next tick, permanently excluding the interface.
QR-code consumers already gate on `if pw`, so `""` is correctly
treated as "no password available".

## Result

- First tick after HA start: 4–6 errors (one-time, while sentinel is written)
- Every subsequent tick: **0 errors**
- Verified across multiple log captures on Keenetic Hopper (KN-3810)
  with Guest Wi-Fi disabled