### PR TITLE
feat(button): add per-client Wake-on-LAN button

### DIFF
--- a/custom_components/keenetic_router_pro/api.py
+++ b/custom_components/keenetic_router_pro/api.py
@@ -3415,6 +3415,23 @@ class KeeneticClient:
         await self._rci_parse(cmd)
         await self._rci_parse("system configuration save")
 
+    async def async_wake_client(self, mac: str) -> None:
+        """Send a Wake-on-LAN magic packet to a client via ``ip hotspot wake``.
+
+        This mirrors the "Wake on LAN" button in the Keenetic web UI / My.Keenetic
+        app, which is implemented on the router side by the CLI command
+        ``ip hotspot wake {mac}`` (introduced in NDMS 2.08). It's a one-shot
+        action, not a config change, so unlike async_set_client_bandwidth /
+        async_set_client_policy there is no following "system configuration
+        save" — nothing is persisted to the running config.
+        """
+        mac_clean = mac.lower().replace("-", ":")
+        safe_mac = _validate_cli_arg(mac_clean, "client mac")
+
+        cmd = f"ip hotspot wake {safe_mac}"
+        _LOGGER.debug("Sending Wake-on-LAN packet to client %s", mac_clean)
+        await self._rci_parse(cmd)
+
     async def async_get_lte_data_usage(self) -> Dict[str, Dict[str, Any]]:
         """Get traffic-counter (data usage / monthly quota) for LTE WANs.
 

--- a/custom_components/keenetic_router_pro/button.py
+++ b/custom_components/keenetic_router_pro/button.py
@@ -58,6 +58,16 @@ async def async_setup_entry(
                 initial_ip=initial_ip,
             )
         )
+        entities.append(
+            KeeneticClientWakeOnLanButton(
+                coordinator=coordinator,
+                entry=entry,
+                api_client=client,
+                mac=mac,
+                label=name,
+                initial_ip=initial_ip,
+            )
+        )
 
     async_add_entities(entities)
 
@@ -170,3 +180,55 @@ class KeeneticClientClearBandwidthButton(ClientEntity, ButtonEntity):
             )
             raise
         await self.coordinator.async_request_refresh()
+
+class KeeneticClientWakeOnLanButton(ClientEntity, ButtonEntity):
+    """One-tap Wake-on-LAN button per tracked client.
+
+    Mirrors the "Wake on LAN" action available for a client in the Keenetic
+    web UI / My.Keenetic app, sending a magic packet to the client's MAC
+    address via the router's ``ip hotspot wake`` CLI command.
+    """
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:power"
+
+    # Per-client buttons share the client device card with the slider;
+    # they don't read coordinator data themselves, so the fingerprint
+    # dedup machinery doesn't apply.
+    _FINGERPRINT_IGNORE: frozenset = frozenset()
+
+    def __init__(
+        self,
+        coordinator: KeeneticCoordinator,
+        entry: ConfigEntry,
+        api_client: KeeneticClient,
+        mac: str,
+        label: str,
+        initial_ip: str | None,
+    ) -> None:
+        ClientEntity.__init__(
+            self,
+            coordinator=coordinator,
+            entry_id=entry.entry_id,
+            title=entry.title,
+            mac=mac,
+            label=label,
+            initial_ip=initial_ip,
+        )
+        self._api_client = api_client
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._entry_id}_client_{self._mac}_wol"
+
+    @property
+    def name(self) -> str:
+        return "Wake on LAN"
+
+    async def async_press(self, **_: Any) -> None:
+        try:
+            await self._api_client.async_wake_client(self._mac)
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception(
+                "Failed to send Wake-on-LAN packet to client %s", self._mac
+            )
+            raise


### PR DESCRIPTION
Add KeeneticClientWakeOnLanButton for each tracked client, alongside the existing "Clear Bandwidth Limit" button. Adds KeeneticClient.async_wake_client() in the API layer, which sends the ip hotspot wake {mac} RCI command via the existing _rci_parse helper.